### PR TITLE
Clamp window width to positive float to prevent crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ target_wasm
 playlists/playlist-1
 cache/*
 playlists/00*
+
+.idea

--- a/src/song_ui.rs
+++ b/src/song_ui.rs
@@ -316,7 +316,7 @@ pub fn draw_song_card(
                             });
                         });
                         let remaining_width =
-                            ui.available_width() - 60.0;
+                            (ui.available_width() - 60.0).clamp(0.0, f32::MAX);
                         ui.allocate_ui_with_layout(
                             egui::vec2(
                                 remaining_width,


### PR DESCRIPTION
This PR clamps the desired window width to be positive to prevent a panic in egui. 



Closes #47.

